### PR TITLE
Added OrderBy to pop so the queue will work in fifo mode.

### DIFF
--- a/src/DatabaseQueue.php
+++ b/src/DatabaseQueue.php
@@ -94,6 +94,7 @@ class DatabaseQueue extends Queue implements QueueInterface {
 			->where('queue', '=', $queue)
 			->where('status', '=', Job::STATUS_OPEN)
 			->orWhere('status', '=', Job::STATUS_WAITING)
+			->orderBy('id')
 			->first()
 			;
 


### PR DESCRIPTION
A pure select without ordering was returning the  lines in random order in our database.

Our project needs the queue to start jobs in the same order as they were added(unless delayed) because a process chain of "do X" -> "revert X" -> "do X differently" is possible so having the order of operations change was a problem.
