### PR TITLE
Untangle from SyncJOb

### DIFF
--- a/src/DatabaseQueue.php
+++ b/src/DatabaseQueue.php
@@ -1,5 +1,6 @@
 <?php namespace Davelip\Queue;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Queue\Queue;
 use Illuminate\Queue\QueueInterface;
 use Symfony\Component\Process\Process;
@@ -92,8 +93,10 @@ class DatabaseQueue extends Queue implements QueueInterface {
 
 		$job = Job::where('timestamp', '<', date('Y-m-d H:i:s', time()))
 			->where('queue', '=', $queue)
-			->where('status', '=', Job::STATUS_OPEN)
-			->orWhere('status', '=', Job::STATUS_WAITING)
+			->where(function(Builder $query) {
+				$query->where('status', '=', Job::STATUS_OPEN);
+				$query->orWhere('status', '=', Job::STATUS_WAITING);
+			})
 			->orderBy('id')
 			->first()
 			;

--- a/src/Jobs/DatabaseJob.php
+++ b/src/Jobs/DatabaseJob.php
@@ -144,7 +144,9 @@ class DatabaseJob extends \Illuminate\Queue\Jobs\Job
 	 * @return string
 	 */
 	public function getRawBody() {
-		// TODO: Find out what this needs to return
+		// FIXME: This is a best guess, other implementations are used like this:  $this->resolveAndFire(json_decode($this->getRawBody(), true));
+
+		return $this->job->payload;
 	}
 
 

--- a/src/Jobs/DatabaseJob.php
+++ b/src/Jobs/DatabaseJob.php
@@ -1,10 +1,9 @@
 <?php namespace Davelip\Queue\Jobs;
 
 use Davelip\Queue\Models\Job;
-use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Container\Container;
 
-class DatabaseJob extends SyncJob
+class DatabaseJob extends Illuminate\Queue\Jobs\Job
 {
 	/**
 	 * The job model
@@ -68,7 +67,7 @@ class DatabaseJob extends SyncJob
 		$this->job->delete();
 	}
 
-	/*
+	/**
 	 * Release the job back into the queue.
 	 *
 	 * @param  int   $delay
@@ -76,10 +75,11 @@ class DatabaseJob extends SyncJob
 	 */
 	public function release($delay = 0)
 	{
+		$now = new Carbon();
+		$now->addSeconds($delay);
+		$this->job->timestamp = $now->timestamp;
 		$this->job->status = Job::STATUS_WAITING;
 		$this->job->save();
-
-		$this->delete();
 	}
 
 	/**
@@ -104,6 +104,14 @@ class DatabaseJob extends SyncJob
 		return $this->name;
 	}
 
+	/**
+	 * Get the number of attempts this task has been done
+	 *
+	 * @return int
+	 */
+	public function attempts() {
+		return ($this->job->retries + 1);
+	}
 
 	/**
 	 * Get the job identifier.

--- a/src/Jobs/DatabaseJob.php
+++ b/src/Jobs/DatabaseJob.php
@@ -103,4 +103,15 @@ class DatabaseJob extends SyncJob
 	{
 		return $this->name;
 	}
+
+
+	/**
+	 * Get the job identifier.
+	 *
+	 * @return string
+	 */
+	public function getJobId()
+	{
+		return $this->job->getKey();
+	}
 }


### PR DESCRIPTION
Various Fixes:
- Grouped the where statements in DatabaseQueue::pop for state 'waiting' and 'open'.
  ungrouped it selected all jobs in state 'waiting', without regard to queue and timestamp
- Switched baseclass from SyncJob to the underlying abstract Job, as all SyncJob methods have now been overriden.
- Fixed release
  Before: Set state to waiting, then delete the job.
  Now: Set state to waiting, set Timestamp to now + $delay seconds, set Flag so the job won't be set to finished after running, increment retries
- Fixed attempts
  Now returns $model->retries + 1 instead of a static 1
- Fixed getJobId
  Now returns $model->getKey() instead of ''
- Added getRawBody
  This is my best guess to what this method should do.
  It seems to return the raw json payload in other implementations, so $model->payload seems right
