### PR TITLE
fixed type timestamp to datetime

### DIFF
--- a/src/DatabaseQueue.php
+++ b/src/DatabaseQueue.php
@@ -209,8 +209,9 @@ class DatabaseQueue extends Queue implements QueueInterface
             'queue' => $this->getQueue($queue),
             'payload' => $payload,
             'retries' => $attempts,
-            'timestamp' => $availableAt->getTimestamp(),
-            'created_at' => $this->getTime(),
+            'timestamp' => date('Y-m-d H:i:s',$availableAt->getTimestamp()),
+            'created_at' => date('Y-m-d H:i:s',$this->getTime()) ,
+            'updated_at' => date('Y-m-d H:i:s',$this->getTime()),
         ]);
     }
 


### PR DESCRIPTION
1. pushToDatabase  need instert to `updated_at`
`updated_at` was created for `$table->timestamps();` and this is notnull
https://github.com/laravel/framework/blob/4.2/src/Illuminate/Database/Schema/Blueprint.php#L632
because it need to insert to 'updated_at'

2. `created_at` and `updated_at` is type of `datetime`
`$availableAt->getTimestamp()` and `$this->getTime()` return type of  `int`